### PR TITLE
Setup GitHub Pages with basic index

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,32 @@
+name: Deploy static content to Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy-pages.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: .
+      - name: Deploy to GitHub Pages
+        id: deploy-pages
+        uses: actions/deploy-pages@v2

--- a/index.html
+++ b/index.html
@@ -1,1 +1,11 @@
-temp
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>The Floor</title>
+</head>
+<body>
+  <h1>The Floor</h1>
+  <p>Welcome to The Floor static site served with GitHub Pages.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add simple `index.html` for GitHub Pages.
- Configure GitHub Pages deployment via GitHub Actions workflow.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c57d70059c8320bcff6aa76ad04efc