### PR TITLE
Fix GitHub Pages routing for The Floor game

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8" />
+  <meta http-equiv="refresh" content="0; url=project/web/index.html" />
   <title>The Floor</title>
 </head>
 <body>
-  <h1>The Floor</h1>
-  <p>Welcome to The Floor static site served with GitHub Pages.</p>
+  <p>Redirecting to <a href="project/web/index.html">project/web/index.html</a>...</p>
 </body>
 </html>

--- a/project/web/operator.js
+++ b/project/web/operator.js
@@ -165,7 +165,7 @@ function initClock(total) {
 
 document.getElementById('open-display').addEventListener('click', () => {
   // open audience display in new window
-  window.open('/web/display.html', 'display');
+  window.open('display.html', 'display');
 });
 
 document.getElementById('apply-total').addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- Redirect root index.html to project/web index so GitHub Pages loads the game
- Use relative link for display window so local and Pages paths work

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5846b9cf0832097f51752f4c28738