### PR TITLE
Add between-battles controls and random player screen

### DIFF
--- a/project/web/app.js
+++ b/project/web/app.js
@@ -27,6 +27,7 @@ export function freshState() {
     lastSavedAt: Date.now(),
     scene: 'lobby',
     players: [],
+    randomPlayerId: null,
     clock: {
       totalMs: 0,
       leftRemainingMs: 0,

--- a/project/web/display.js
+++ b/project/web/display.js
@@ -18,6 +18,10 @@ function render() {
   const scene = state.scene;
   if (scene === 'lobby') {
     root.innerHTML = '<h1>Arena Floor</h1>' + renderPlayers();
+  } else if (scene === 'random_player') {
+    const p = state.players.find(p=>p.id===state.randomPlayerId);
+    const name = p ? p.name : '';
+    root.innerHTML = `<h1>${name}</h1>`;
   } else if (scene === 'category_select') {
     root.innerHTML = '<h1>Stand by</h1>';
   } else if (scene === 'duel_ready') {

--- a/project/web/operator.html
+++ b/project/web/operator.html
@@ -13,6 +13,14 @@
     <button id="add-player">Add Player</button>
   </section>
 
+  <section id="between-battles">
+    <h2>Between Battles</h2>
+    <div class="controls">
+      <button id="show-players-screen">Show Players Screen</button>
+      <button id="show-random-player">Show Random Player</button>
+    </div>
+  </section>
+
   <section id="duel-setup">
     <h2>Duel Setup</h2>
     <div>

--- a/project/web/operator.js
+++ b/project/web/operator.js
@@ -91,6 +91,27 @@ document.getElementById('player-list').addEventListener('click', e => {
   }
 });
 
+// Between battles ------------------------------------------------------
+
+document.getElementById('show-players-screen').addEventListener('click', () => {
+  state.scene = 'lobby';
+  saveState(state);
+});
+
+document.getElementById('show-random-player').addEventListener('click', () => {
+  const alive = state.players.filter(p => !p.eliminated);
+  const zero = alive.filter(p => p.score === 0);
+  const pool = zero.length ? zero : alive;
+  if (!pool.length) {
+    alert('No players available');
+    return;
+  }
+  const choice = pool[Math.floor(Math.random() * pool.length)];
+  state.randomPlayerId = choice.id;
+  state.scene = 'random_player';
+  saveState(state);
+});
+
 // Duel selectors -------------------------------------------------------
 function renderDuelSelectors() {
   const leftSel = document.getElementById('left-player');


### PR DESCRIPTION
## Summary
- Insert "Between Battles" section in operator UI with controls to show players screen or spotlight a random player.
- Implement random player selection prioritizing active players with score 0 and broadcast to new display scene.
- Extend display and state to support random player scene.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6e8d8ed088320a2106b4227c967c8