### PR TITLE
Display current answer on operator screen

### DIFF
--- a/project/web/operator.html
+++ b/project/web/operator.html
@@ -44,6 +44,7 @@
 
   <section id="duel-battle">
     <h2>Duel Battle</h2>
+    <div class="answer">Answer: <span id="current-answer"></span></div>
     <div class="controls">
       <button id="pause-duel">Pause</button>
       <button id="correct" class="primary">Correct</button>

--- a/project/web/operator.js
+++ b/project/web/operator.js
@@ -38,6 +38,7 @@ async function init() {
   renderDuelSelectors();
   tickLoop();
   updateDisplayStatus();
+  renderAnswer();
 }
 
 // Player management ----------------------------------------------------
@@ -137,6 +138,12 @@ function renderDuelSelectors() {
   });
 });
 
+function renderAnswer() {
+  const el = document.getElementById('current-answer');
+  if (!el) return;
+  el.textContent = state.current?.answer || '';
+}
+
 async function populateCategories() {
   const manifest = await loadManifest();
   const catSel = document.getElementById('category');
@@ -173,6 +180,7 @@ document.getElementById('item').addEventListener('change', async e => {
   state.current = { categoryId: cat.id, itemIndex: item.index, src: item.src, answer: item.answer, revealed:false };
   state.scene = 'duel_ready';
   saveState(state);
+  renderAnswer();
 });
 
 async function ensureCurrentItem() {
@@ -188,6 +196,7 @@ async function ensureCurrentItem() {
   const itemSel = document.getElementById('item');
   if (itemSel) itemSel.value = item.index;
   state.scene = 'duel_ready';
+  renderAnswer();
 }
 
 // Clock and duel control -----------------------------------------------
@@ -268,6 +277,7 @@ async function advanceItem() {
     const itemSel = document.getElementById('item');
     if (itemSel) itemSel.value = '';
   }
+  renderAnswer();
 }
 
 async function switchTurn(side) {
@@ -411,6 +421,7 @@ document.getElementById('edit-json').addEventListener('click', () => {
       saveState(state);
       renderPlayers();
       renderDuelSelectors();
+      renderAnswer();
       modal.classList.add('hidden');
     } catch (e) {
       alert('Invalid JSON: ' + e.message);
@@ -439,6 +450,7 @@ document.getElementById('import-file').addEventListener('change', async e => {
     saveState(state);
     renderPlayers();
     renderDuelSelectors();
+    renderAnswer();
     alert('Import successful');
   } catch (err) {
     alert('Import failed: ' + err.message);
@@ -453,6 +465,7 @@ document.getElementById('reset-show').addEventListener('click', () => {
     saveState(state);
     renderPlayers();
     renderDuelSelectors();
+    renderAnswer();
     alert('Show reset');
   }
 });


### PR DESCRIPTION
## Summary
- Show current answer in the duel battle section of the operator interface
- Keep answer readout up to date when questions change or advance

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6ff59fde48320b6d4081801646e67