### PR TITLE
Add player field to manifest categories

### DIFF
--- a/project/tools/build_manifest.py
+++ b/project/tools/build_manifest.py
@@ -3,7 +3,7 @@
 Manifest builder for Arena Floor.
 
 Usage:
-1. Put images under project/GameFolder/<CategoryName>/
+1. Put images under project/GameFolder/<Player - Category>/
 2. From project/, run: python tools/build_manifest.py
 3. Serve project/ statically (e.g., python -m http.server) and open /web/operator.html
 """
@@ -24,7 +24,11 @@ def slugify(name: str) -> str:
 def build_manifest(root: Path) -> dict:
     categories = []
     for cat_dir in sorted(p for p in root.iterdir() if p.is_dir()):
-        cat_name = cat_dir.name
+        folder_name = cat_dir.name
+        if ' - ' in folder_name:
+            player, cat_name = folder_name.split(' - ', 1)
+        else:
+            player, cat_name = '', folder_name
         cat_id = slugify(cat_name)
         items = []
         files = [p for p in cat_dir.iterdir() if p.is_file() and p.suffix.lower() in EXTS]
@@ -40,9 +44,9 @@ def build_manifest(root: Path) -> dict:
                 answer = f.stem
                 auto_index += 1
             item_id = f"{cat_id}-{index}"
-            src = '/' + str((GAME_FOLDER / cat_name / f.name).as_posix())
+            src = '/' + str((cat_dir / f.name).as_posix())
             items.append({'id': item_id, 'index': index, 'answer': answer, 'src': src})
-        categories.append({'id': cat_id, 'name': cat_name, 'items': items})
+        categories.append({'id': cat_id, 'name': cat_name, 'player': player, 'items': items})
     return {
         'version': 1,
         'generatedAt': datetime.datetime.utcnow().isoformat() + 'Z',

--- a/project/web/manifest.json
+++ b/project/web/manifest.json
@@ -1,52 +1,79 @@
 {
   "version": 1,
-  "generatedAt": "2025-09-14T15:52:21.139517Z",
+  "generatedAt": "2025-09-14T18:16:53.345300Z",
   "categories": [
-    {
-      "id": "shoe-brands",
-      "name": "Shoe Brands",
-      "items": [
-        {
-          "id": "shoe-brands-1",
-          "index": 1,
-          "answer": "Nike",
-          "src": "/GameFolder/Shoe Brands/1 - Nike.png"
-        },
-        {
-          "id": "shoe-brands-2",
-          "index": 2,
-          "answer": "Addidas",
-          "src": "/GameFolder/Shoe Brands/2 - Addidas.png"
-        },
-        {
-          "id": "shoe-brands-3",
-          "index": 3,
-          "answer": "Blundstones",
-          "src": "/GameFolder/Shoe Brands/3 - Blundstones.png"
-        }
-      ]
-    },
     {
       "id": "transportation",
       "name": "Transportation",
+      "player": "Omri",
       "items": [
         {
           "id": "transportation-1",
           "index": 1,
           "answer": "Bike",
-          "src": "/GameFolder/Transportation/1 - Bike.png"
+          "src": "/GameFolder/Omri - Transportation/1 - Bike.png"
         },
         {
           "id": "transportation-2",
           "index": 2,
           "answer": "Bus",
-          "src": "/GameFolder/Transportation/2 - Bus.png"
+          "src": "/GameFolder/Omri - Transportation/2 - Bus.png"
         },
         {
           "id": "transportation-3",
           "index": 3,
           "answer": "Car",
-          "src": "/GameFolder/Transportation/3 - Car.png"
+          "src": "/GameFolder/Omri - Transportation/3 - Car.png"
+        }
+      ]
+    },
+    {
+      "id": "shoe-brands",
+      "name": "Shoe Brands",
+      "player": "Ron",
+      "items": [
+        {
+          "id": "shoe-brands-1",
+          "index": 1,
+          "answer": "Nike",
+          "src": "/GameFolder/Ron - Shoe Brands/1 - Nike.png"
+        },
+        {
+          "id": "shoe-brands-2",
+          "index": 2,
+          "answer": "Addidas",
+          "src": "/GameFolder/Ron - Shoe Brands/2 - Addidas.png"
+        },
+        {
+          "id": "shoe-brands-3",
+          "index": 3,
+          "answer": "Blundstones",
+          "src": "/GameFolder/Ron - Shoe Brands/3 - Blundstones.png"
+        }
+      ]
+    },
+    {
+      "id": "untitled",
+      "name": "נעליים",
+      "player": "בועז",
+      "items": [
+        {
+          "id": "untitled-1",
+          "index": 1,
+          "answer": "Nike",
+          "src": "/GameFolder/בועז - נעליים/1 - Nike.png"
+        },
+        {
+          "id": "untitled-2",
+          "index": 2,
+          "answer": "Addidas",
+          "src": "/GameFolder/בועז - נעליים/2 - Addidas.png"
+        },
+        {
+          "id": "untitled-3",
+          "index": 3,
+          "answer": "Blundstones",
+          "src": "/GameFolder/בועז - נעליים/3 - Blundstones.png"
         }
       ]
     }

--- a/project/web/manifest.json
+++ b/project/web/manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2025-09-14T18:16:53.345300Z",
+  "generatedAt": "2025-09-14T18:22:32.275861Z",
   "categories": [
     {
       "id": "transportation",


### PR DESCRIPTION
## Summary
- Parse `Player - Category` directories and extract player names
- Include `player` field for each category in generated manifest

## Testing
- `python tools/build_manifest.py`
- `python -m py_compile tools/build_manifest.py`


------
https://chatgpt.com/codex/tasks/task_e_68c70656274883209e62f19814a3fe9e