### PR TITLE
feat: show players in grid and expand winner territories

### DIFF
--- a/project/web/app.js
+++ b/project/web/app.js
@@ -16,7 +16,12 @@ export async function loadManifest() {
 }
 
 export function migrateState(s) {
-  // placeholder for future migrations
+  // ensure new properties exist
+  if (s.players) {
+    s.players.forEach(p => {
+      if (p.cells == null) p.cells = 1;
+    });
+  }
   return s;
 }
 
@@ -28,6 +33,7 @@ export function freshState() {
     scene: 'lobby',
     players: [],
     randomPlayerId: null,
+    grid: { rows: 0, cols: 0, cells: [] },
     clock: {
       totalMs: 0,
       leftRemainingMs: 0,

--- a/project/web/display.js
+++ b/project/web/display.js
@@ -66,8 +66,48 @@ function render() {
 }
 
 function renderPlayers() {
-  if (!state.players.length) return '';
-  return '<ul>' + state.players.map(p=>`<li>${p.name}${p.eliminated?' (out)':''} - ${p.score}</li>`).join('') + '</ul>';
+  if (!state.players.length || !state.grid) return '';
+  const grid = state.grid;
+  const container = document.createElement('div');
+  container.className = 'player-grid';
+  container.style.gridTemplateColumns = `repeat(${grid.cols}, 1fr)`;
+  container.style.gridTemplateRows = `repeat(${grid.rows}, 1fr)`;
+  const areaRows = [];
+  for (let r = 0; r < grid.rows; r++) {
+    const names = [];
+    for (let c = 0; c < grid.cols; c++) {
+      names.push(`c${r}_${c}`);
+    }
+    areaRows.push(`'${names.join(' ')}'`);
+  }
+  container.style.gridTemplateAreas = areaRows.join(' ');
+  for (let r = 0; r < grid.rows; r++) {
+    for (let c = 0; c < grid.cols; c++) {
+      const idx = r * grid.cols + c;
+      const area = `c${r}_${c}`;
+      const pid = grid.cells[idx];
+      const cell = document.createElement('div');
+      cell.style.gridArea = area;
+      cell.className = 'player-cell';
+      if (pid) {
+        const player = state.players.find(p => p.id === pid);
+        cell.style.background = playerColor(pid);
+        cell.style.color = '#000';
+        cell.textContent = `${player?.name || ''} - ${player?.score || 0}`;
+      }
+      container.appendChild(cell);
+    }
+  }
+  return container.outerHTML;
+}
+
+function playerColor(id) {
+  let hash = 0;
+  for (let i = 0; i < id.length; i++) {
+    hash = (hash * 31 + id.charCodeAt(i)) >>> 0;
+  }
+  const hue = hash % 360;
+  return `hsl(${hue}, 70%, 70%)`;
 }
 
 channel.onmessage = e => {

--- a/project/web/display.js
+++ b/project/web/display.js
@@ -72,33 +72,41 @@ function renderPlayers() {
   container.className = 'player-grid';
   container.style.gridTemplateColumns = `repeat(${grid.cols}, 1fr)`;
   container.style.gridTemplateRows = `repeat(${grid.rows}, 1fr)`;
+  container.style.gap = '0';
   const areaRows = [];
+  const used = new Set();
   for (let r = 0; r < grid.rows; r++) {
     const names = [];
     for (let c = 0; c < grid.cols; c++) {
-      names.push(`c${r}_${c}`);
+      const idx = r * grid.cols + c;
+      const pid = grid.cells[idx];
+      if (pid) {
+        const an = areaName(pid);
+        names.push(an);
+        used.add(pid);
+      } else {
+        names.push('.');
+      }
     }
-    areaRows.push(`'${names.join(' ')}'`);
+    areaRows.push(`"${names.join(' ')}"`);
   }
   container.style.gridTemplateAreas = areaRows.join(' ');
-  for (let r = 0; r < grid.rows; r++) {
-    for (let c = 0; c < grid.cols; c++) {
-      const idx = r * grid.cols + c;
-      const area = `c${r}_${c}`;
-      const pid = grid.cells[idx];
-      const cell = document.createElement('div');
-      cell.style.gridArea = area;
-      cell.className = 'player-cell';
-      if (pid) {
-        const player = state.players.find(p => p.id === pid);
-        cell.style.background = playerColor(pid);
-        cell.style.color = '#000';
-        cell.textContent = `${player?.name || ''} - ${player?.score || 0}`;
-      }
-      container.appendChild(cell);
-    }
-  }
+  used.forEach(pid => {
+    const player = state.players.find(p => p.id === pid);
+    if (!player) return;
+    const cell = document.createElement('div');
+    cell.className = 'player-area';
+    cell.style.gridArea = areaName(pid);
+    cell.style.background = playerColor(pid);
+    cell.style.color = '#000';
+    cell.textContent = `${player.name} - ${player.score}`;
+    container.appendChild(cell);
+  });
   return container.outerHTML;
+}
+
+function areaName(id) {
+  return `p${id.replace(/[^a-zA-Z0-9]/g, '')}`;
 }
 
 function playerColor(id) {

--- a/project/web/display.js
+++ b/project/web/display.js
@@ -73,40 +73,27 @@ function renderPlayers() {
   container.style.gridTemplateColumns = `repeat(${grid.cols}, 1fr)`;
   container.style.gridTemplateRows = `repeat(${grid.rows}, 1fr)`;
   container.style.gap = '0';
-  const areaRows = [];
   const used = new Set();
+
   for (let r = 0; r < grid.rows; r++) {
-    const names = [];
     for (let c = 0; c < grid.cols; c++) {
       const idx = r * grid.cols + c;
       const pid = grid.cells[idx];
+      const cell = document.createElement('div');
+      cell.className = 'player-cell';
       if (pid) {
-        const an = areaName(pid);
-        names.push(an);
-        used.add(pid);
-      } else {
-        names.push('.');
+        const player = state.players.find(p => p.id === pid);
+        cell.style.background = playerColor(pid);
+        cell.style.color = '#000';
+        if (player && !used.has(pid)) {
+          cell.textContent = `${player.name} - ${player.score}`;
+          used.add(pid);
+        }
       }
+      container.appendChild(cell);
     }
-    areaRows.push(`"${names.join(' ')}"`);
   }
-  container.style.gridTemplateAreas = areaRows.join(' ');
-  used.forEach(pid => {
-    const player = state.players.find(p => p.id === pid);
-    if (!player) return;
-    const cell = document.createElement('div');
-    cell.className = 'player-area';
-    cell.style.gridArea = areaName(pid);
-    cell.style.background = playerColor(pid);
-    cell.style.color = '#000';
-    cell.textContent = `${player.name} - ${player.score}`;
-    container.appendChild(cell);
-  });
   return container.outerHTML;
-}
-
-function areaName(id) {
-  return `p${id.replace(/[^a-zA-Z0-9]/g, '')}`;
 }
 
 function playerColor(id) {

--- a/project/web/operator.js
+++ b/project/web/operator.js
@@ -144,10 +144,10 @@ function ensureGrid() {
   const total = state.players.reduce((sum,p)=>sum + (p.cells||0), 0);
   const cols = Math.ceil(Math.sqrt(total));
   const rows = Math.ceil(total / cols);
-  if (!state.grid || state.grid.rows !== rows || state.grid.cols !== cols || state.grid.cells.length !== rows*cols) {
-    const cells = [];
-    state.players.forEach(p => { for (let i=0;i<(p.cells||0);i++) cells.push(p.id); });
-    while (cells.length < rows*cols) cells.push(null);
+  const cells = [];
+  state.players.forEach(p => { for (let i=0;i<(p.cells||0);i++) cells.push(p.id); });
+  while (cells.length < rows*cols) cells.push(null);
+  if (!state.grid || state.grid.rows !== rows || state.grid.cols !== cols || state.grid.cells.length !== rows*cols || state.grid.cells.some((id,i)=>id!==cells[i])) {
     state.grid = { rows, cols, cells };
     changed = true;
   }
@@ -165,6 +165,7 @@ function transferGridAreas(winnerId, loserId) {
   const lose = state.players.find(p=>p.id===loserId);
   if (win) win.cells = (win.cells || 0) + moved;
   if (lose) lose.cells = 0;
+  ensureGrid();
 }
 
 // Between battles ------------------------------------------------------

--- a/project/web/styles.css
+++ b/project/web/styles.css
@@ -19,3 +19,5 @@ button, input, select {
 .modal { background:#222; padding:1rem; position:fixed; top:10%; left:10%; right:10%; bottom:10%; }
 .hidden { display:none; }
 .overlay { position:fixed; top:0; left:0; right:0; bottom:0; background:rgba(0,0,0,0.7); display:flex; align-items:center; justify-content:center; font-size:3rem; }
+.player-grid { display:grid; gap:4px; width:100%; height:80vh; }
+.player-cell { display:flex; align-items:center; justify-content:center; border:1px solid #333; font-weight:bold; }

--- a/project/web/styles.css
+++ b/project/web/styles.css
@@ -20,4 +20,4 @@ button, input, select {
 .hidden { display:none; }
 .overlay { position:fixed; top:0; left:0; right:0; bottom:0; background:rgba(0,0,0,0.7); display:flex; align-items:center; justify-content:center; font-size:3rem; }
 .player-grid { display:grid; width:100%; height:80vh; }
-.player-area { display:flex; align-items:center; justify-content:center; font-weight:bold; }
+.player-cell { display:flex; align-items:center; justify-content:center; font-weight:bold; }

--- a/project/web/styles.css
+++ b/project/web/styles.css
@@ -19,5 +19,5 @@ button, input, select {
 .modal { background:#222; padding:1rem; position:fixed; top:10%; left:10%; right:10%; bottom:10%; }
 .hidden { display:none; }
 .overlay { position:fixed; top:0; left:0; right:0; bottom:0; background:rgba(0,0,0,0.7); display:flex; align-items:center; justify-content:center; font-size:3rem; }
-.player-grid { display:grid; gap:4px; width:100%; height:80vh; }
-.player-cell { display:flex; align-items:center; justify-content:center; border:1px solid #333; font-weight:bold; }
+.player-grid { display:grid; width:100%; height:80vh; }
+.player-area { display:flex; align-items:center; justify-content:center; font-weight:bold; }


### PR DESCRIPTION
## Summary
- add grid state to game data and ensure it's generated
- display lobby players in color-coded grid and render takeover on eliminations
- allow winners to seize eliminated players' grid sections

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7100da3608320938a58512fe7ec0d