### PR TITLE
Fix winner display to respect declared duel outcome

### DIFF
--- a/project/web/app.js
+++ b/project/web/app.js
@@ -22,6 +22,7 @@ export function migrateState(s) {
       if (p.cells == null) p.cells = 1;
     });
   }
+  if (s.winnerId === undefined) s.winnerId = null;
   return s;
 }
 
@@ -44,6 +45,7 @@ export function freshState() {
     },
     penaltyUntil: null,
     correctUntil: null,
+    winnerId: null,
   };
 }
 

--- a/project/web/display.js
+++ b/project/web/display.js
@@ -60,7 +60,13 @@ function render() {
   } else if (scene === 'result') {
     const left = state.players.find(p=>p.id===state.leftPlayerId)?.name || 'Left';
     const right = state.players.find(p=>p.id===state.rightPlayerId)?.name || 'Right';
-    const winner = state.clock.leftRemainingMs > state.clock.rightRemainingMs ? left : right;
+    let winner;
+    if (state.winnerId) {
+      winner = state.players.find(p => p.id === state.winnerId)?.name;
+    }
+    if (!winner) {
+      winner = state.clock.leftRemainingMs > state.clock.rightRemainingMs ? left : right;
+    }
     root.innerHTML = `<h1>Winner: ${winner}</h1>`;
   }
 }

--- a/project/web/operator.js
+++ b/project/web/operator.js
@@ -319,6 +319,7 @@ function initClock(total) {
   state.scene = 'duel_live';
   state.penaltyUntil = null;
   state.correctUntil = null;
+  state.winnerId = null;
 }
 
 document.getElementById('open-display').addEventListener('click', () => {
@@ -418,6 +419,7 @@ function timeout() {
   const winId = winner === 'left' ? state.leftPlayerId : state.rightPlayerId;
   const p = state.players.find(x=>x.id===winId);
   if (p) p.score += 1;
+  state.winnerId = winId;
   saveState(state);
   renderPlayers();
 }
@@ -431,6 +433,7 @@ function declareWinner(side) {
   const leftCat = state.players.find(x=>x.id===state.leftPlayerId)?.currCatId;
   const p = state.players.find(x=>x.id===winId);
   if (p) p.score += 1;
+  state.winnerId = winId;
   if (confirm('Eliminate loser?')) {
     const lp = state.players.find(x=>x.id===loseId); if(lp) lp.eliminated = true;
     transferGridAreas(winId, loseId);


### PR DESCRIPTION
## Summary
- Track `winnerId` in shared state so display knows declared winner
- Update operator actions to set/reset `winnerId`
- Render result banner using `winnerId` instead of clock comparison

## Testing
- `node --check project/web/app.js`
- `node --check project/web/operator.js`
- `node --check project/web/display.js`
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c71c3706f483209add0fcc904487ae