### PR TITLE
Refactor score tracking to cell ownership

### DIFF
--- a/initial_spec.md
+++ b/initial_spec.md
@@ -120,7 +120,7 @@ type Settings = {
 type Player = {
   id: string;
   name: string;
-  score: number;
+  cells: number;
   eliminated: boolean;
 };
 ```
@@ -223,7 +223,7 @@ Implement a clean control panel with three main areas:
 
 * Table/list with CRUD:
 
-  * Add player (auto-id UUIDv4), edit name, toggle eliminated, reset score.
+  * Add player (auto-id UUIDv4), edit name, toggle eliminated, reset cells.
   * Remove player (confirm).
 * Always persists changes & broadcasts.
 
@@ -245,7 +245,7 @@ Implement a clean control panel with three main areas:
   * **Correct (Left)** / **Correct (Right)** → triggers **SWITCH_TURN** (stop current side, start the other; used when opponent gives a correct answer).
   * **Reveal Answer** (sets `current.revealed = true`).
   * **Timeout (Force)** — triggers timeout on the currently running side.
-  * **Declare Winner (Left/Right)** — sets scene `result`, updates winner’s `score += 1`, optionally mark loser as eliminated (checkbox option).
+  * **Declare Winner (Left/Right)** — sets scene `result`, optionally transfer territory by eliminating the loser (checkbox option).
   * **Next Item** — moves back to `category_select` or `duel_ready` (your choice), keeps duelists or resets them per UX note in code.
   * **Reset Duel** — re-init duel clocks without changing players/item.
 
@@ -284,7 +284,7 @@ Implement a clean control panel with three main areas:
   * **category_select** — “Stand by”.
   * **duel_ready** — show the two players’ names large, category title.
   * **duel_live** — **big chess-clock** view: two large name panels with remaining times; central **image** (`current.src`) scaled to fit; answer hidden unless `current.revealed === true` or scene changed; a subtle running indicator on the active side.
-  * **result** — winner banner, (optional) score update indicator.
+  * **result** — winner banner, (optional) territory update indicator.
   * **pause** — overlay “Paused”.
 * Responsive, TV-friendly; avoid clutter. No controls.
 

--- a/project/web/app.js
+++ b/project/web/app.js
@@ -18,8 +18,22 @@ export async function loadManifest() {
 export function migrateState(s) {
   // ensure new properties exist
   if (s.players) {
+    const counts = new Map();
+    if (s.grid && Array.isArray(s.grid.cells)) {
+      s.grid.cells.forEach(id => {
+        if (!id) return;
+        counts.set(id, (counts.get(id) || 0) + 1);
+      });
+    }
     s.players.forEach(p => {
-      if (p.cells == null) p.cells = 1;
+      if (!p) return;
+      if (counts.has(p.id)) {
+        p.cells = counts.get(p.id);
+      } else if (p.cells == null) {
+        p.cells = p.eliminated ? 0 : 1;
+      } else if (p.cells < 0) {
+        p.cells = 0;
+      }
     });
   }
   if (s.winnerId === undefined) s.winnerId = null;

--- a/project/web/display.js
+++ b/project/web/display.js
@@ -81,6 +81,11 @@ function renderPlayers() {
   container.style.gap = '0';
   const used = new Set();
   const indexMap = new Map(state.players.map((p, i) => [p.id, i]));
+  const cellCounts = new Map();
+  grid.cells.forEach(pid => {
+    if (!pid) return;
+    cellCounts.set(pid, (cellCounts.get(pid) || 0) + 1);
+  });
   const categoryMap = manifest?.categories
     ? new Map(manifest.categories.map(c => [c.id, c.name]))
     : new Map();
@@ -101,9 +106,12 @@ function renderPlayers() {
             const categoryName = player.currCatId
               ? categoryMap.get(player.currCatId) || player.currCatId
               : '-';
+            const cellsOwned = cellCounts.has(pid)
+              ? cellCounts.get(pid)
+              : (player.cells ?? 0);
             cell.innerHTML = `
               <div class="player-name">${player.name}</div>
-              <div class="player-score">${player.score}</div>
+              <div class="player-cells">${cellsOwned}</div>
               <div class="player-category">${categoryName}</div>
             `.trim();
             used.add(pid);

--- a/project/web/styles.css
+++ b/project/web/styles.css
@@ -132,7 +132,7 @@ select {
   gap: 0.25rem;
 }
 
-.player-score {
+.player-cells {
   font-weight: normal;
   color: rgba(0, 0, 0, 0.7);
 }


### PR DESCRIPTION
## Summary
- manage player cell ownership directly in state, deriving counts from the grid when available and defaulting fresh players without relying on legacy score data
- show controlled cell counts throughout the operator and display UIs, including random player selection and reset handling
- refresh styling and documentation to describe the new cell-based scoring model

## Testing
- No automated tests were run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68cc56f848548320af441a8992aa9b60