### PR TITLE
Refine operator player list layout

### DIFF
--- a/project/web/operator.html
+++ b/project/web/operator.html
@@ -18,7 +18,21 @@
 
   <section id="players">
     <h2>Players</h2>
-    <div id="player-list"></div>
+    <div class="players-table-wrapper">
+      <table id="player-table">
+        <thead>
+          <tr>
+            <th scope="col">Name</th>
+            <th scope="col">Cells</th>
+            <th scope="col">Original Category</th>
+            <th scope="col">Current Category</th>
+            <th scope="col">Eliminated</th>
+            <th scope="col">Actions</th>
+          </tr>
+        </thead>
+        <tbody id="player-list"></tbody>
+      </table>
+    </div>
     <button id="add-player">Add Player</button>
   </section>
 

--- a/project/web/operator.js
+++ b/project/web/operator.js
@@ -99,7 +99,7 @@ async function renderPlayers() {
     elimInput.dataset.id = p.id;
     elimInput.checked = !!p.eliminated;
     elimLabel.appendChild(elimInput);
-    elimLabel.append(' Eliminated');
+    elimLabel.append('💀');
     elimCell.appendChild(elimLabel);
     row.appendChild(elimCell);
 

--- a/project/web/operator.js
+++ b/project/web/operator.js
@@ -62,13 +62,62 @@ async function renderPlayers() {
     });
   }
   state.players.forEach(p => {
-    const div = document.createElement('div');
-    div.className = 'player-row';
-    const orig = p.origCatId ? catMap[p.origCatId] || p.origCatId : '-';
-    const curr = p.currCatId ? catMap[p.currCatId] || p.currCatId : '-';
+    const row = document.createElement('tr');
+    row.className = 'player-row';
+
+    const nameCell = document.createElement('td');
+    nameCell.className = 'player-name';
+    const nameInput = document.createElement('input');
+    nameInput.className = 'p-name';
+    nameInput.dataset.id = p.id;
+    nameInput.value = p.name;
+    nameCell.appendChild(nameInput);
+    row.appendChild(nameCell);
+
+    const cellsCell = document.createElement('td');
+    cellsCell.className = 'player-cells';
     const cells = cellCounts.has(p.id) ? cellCounts.get(p.id) : (p.cells ?? 0);
-    div.innerHTML = `\n      <input value="${p.name}" data-id="${p.id}" class="p-name">\n      <span>Cells: ${cells}</span>\n      <span>Orig: ${orig}</span>\n      <span>Current: ${curr}</span>\n      <label><input type="checkbox" class="p-elim" data-id="${p.id}" ${p.eliminated? 'checked':''}> Eliminated</label>\n      <button class="p-reset" data-id="${p.id}">Reset Cells</button>\n      <button class="p-remove" data-id="${p.id}">Remove</button>`;
-    list.appendChild(div);
+    cellsCell.textContent = cells;
+    row.appendChild(cellsCell);
+
+    const origCell = document.createElement('td');
+    const orig = p.origCatId ? catMap[p.origCatId] || p.origCatId : '-';
+    origCell.textContent = orig;
+    row.appendChild(origCell);
+
+    const currCell = document.createElement('td');
+    const curr = p.currCatId ? catMap[p.currCatId] || p.currCatId : '-';
+    currCell.textContent = curr;
+    row.appendChild(currCell);
+
+    const elimCell = document.createElement('td');
+    elimCell.className = 'player-eliminated';
+    const elimLabel = document.createElement('label');
+    const elimInput = document.createElement('input');
+    elimInput.type = 'checkbox';
+    elimInput.className = 'p-elim';
+    elimInput.dataset.id = p.id;
+    elimInput.checked = !!p.eliminated;
+    elimLabel.appendChild(elimInput);
+    elimLabel.append(' Eliminated');
+    elimCell.appendChild(elimLabel);
+    row.appendChild(elimCell);
+
+    const actionsCell = document.createElement('td');
+    actionsCell.className = 'player-actions';
+    const resetButton = document.createElement('button');
+    resetButton.className = 'p-reset';
+    resetButton.dataset.id = p.id;
+    resetButton.textContent = 'Reset Cells';
+    const removeButton = document.createElement('button');
+    removeButton.className = 'p-remove';
+    removeButton.dataset.id = p.id;
+    removeButton.textContent = 'Remove';
+    actionsCell.appendChild(resetButton);
+    actionsCell.appendChild(removeButton);
+    row.appendChild(actionsCell);
+
+    list.appendChild(row);
   });
 }
 

--- a/project/web/styles.css
+++ b/project/web/styles.css
@@ -140,3 +140,63 @@ select {
 .player-category {
   font-weight: normal;
 }
+
+#players .players-table-wrapper {
+  overflow-x: auto;
+}
+
+#players table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 640px;
+  background-color: rgba(0, 0, 0, 0.25);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+#players th,
+#players td {
+  padding: 0.5rem 0.75rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+#players th {
+  background-color: rgba(255, 255, 255, 0.08);
+  font-weight: 600;
+}
+
+#players tbody tr:nth-child(even) {
+  background-color: rgba(255, 255, 255, 0.04);
+}
+
+#players tbody tr:hover {
+  background-color: rgba(255, 255, 255, 0.08);
+}
+
+#players input.p-name {
+  width: 100%;
+  box-sizing: border-box;
+  background: rgba(0, 0, 0, 0.3);
+  color: inherit;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  padding: 0.25rem 0.5rem;
+}
+
+#players td.player-actions {
+  white-space: nowrap;
+}
+
+#players td.player-eliminated,
+#players td.player-cells {
+  text-align: center;
+}
+
+#players td.player-cells {
+  font-variant-numeric: tabular-nums;
+}
+
+#players td.player-actions button {
+  margin: 0.2rem;
+}

--- a/project/web/styles.css
+++ b/project/web/styles.css
@@ -132,7 +132,7 @@ select {
   gap: 0.25rem;
 }
 
-.player-cells {
+.player-grid .player-cells {
   font-weight: normal;
   color: rgba(0, 0, 0, 0.7);
 }
@@ -143,16 +143,12 @@ select {
 
 #players .players-table-wrapper {
   overflow-x: auto;
+  scrollbar-width: thin;
 }
 
 #players table {
-  width: 100%;
   border-collapse: collapse;
-  min-width: 640px;
   background-color: rgba(0, 0, 0, 0.25);
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  border-radius: 6px;
-  overflow: hidden;
 }
 
 #players th,
@@ -160,6 +156,10 @@ select {
   padding: 0.5rem 0.75rem;
   text-align: left;
   border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+#players td.player-name {
+  min-width: 16ch;
 }
 
 #players th {


### PR DESCRIPTION
## Summary
- replace the freeform player list with a table that has consistent columns
- render player rows with DOM nodes so inputs and actions align inside the table
- style the players table for readability, adding alternating rows and responsive scrolling

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc5dea21808320bf1a72473977ccd5