### PR TITLE
Stop broadcasting idle duel ticks to the display

### DIFF
--- a/project/web/app.js
+++ b/project/web/app.js
@@ -74,10 +74,11 @@ export function loadState() {
   }
 }
 
-export function saveState(state) {
+export function saveState(state, options = {}) {
+  const { broadcast = true } = options;
   state.lastSavedAt = Date.now();
   localStorage.setItem(LS_STATE, JSON.stringify(state));
-  channel.postMessage(state);
+  if (broadcast) channel.postMessage(state);
   updateLastSavedUI(state.lastSavedAt);
 }
 

--- a/project/web/operator.js
+++ b/project/web/operator.js
@@ -644,7 +644,7 @@ function tickLoop() {
     if (state.clock.leftRemainingMs <=0 || state.clock.rightRemainingMs<=0) {
       timeout();
     } else {
-      saveState(state);
+      saveState(state, { broadcast: state.scene === 'duel_live' });
     }
   }, 50);
 }


### PR DESCRIPTION
## Summary
- allow `saveState` to skip posting to the BroadcastChannel
- mute operator tick loop broadcasts when the duel scene is not live while still persisting state

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cc5e60eea483208fc1832f051ae2f2