### PR TITLE
Embed winner and standby states into duel screen

### DIFF
--- a/project/web/styles.css
+++ b/project/web/styles.css
@@ -76,7 +76,7 @@ select {
 }
 .status-banner {
   position: fixed;
-  top: 1rem;
+  top: 2.5rem;
   left: 50%;
   transform: translateX(-50%);
   background: rgba(0, 0, 0, 0.7);

--- a/project/web/styles.css
+++ b/project/web/styles.css
@@ -74,12 +74,34 @@ select {
 .clock.correct {
   color: lime;
 }
+.status-banner {
+  position: fixed;
+  top: 1rem;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(0, 0, 0, 0.7);
+  padding: 0.75rem 2.5rem;
+  border-radius: 999px;
+  font-size: 2.5rem;
+  font-weight: 600;
+  z-index: 10;
+}
 .item {
   width: -webkit-fill-available;
   object-fit: contain;
   max-width: 50%;
   max-height: calc(85vh - 16rem);
   margin-top: 10rem;
+}
+.standby-message {
+  margin: 10rem auto 0;
+  max-width: 60vw;
+  padding: 2.5rem 3rem;
+  border-radius: 1.5rem;
+  background: rgba(0, 0, 0, 0.6);
+  font-size: 3rem;
+  font-weight: 600;
+  line-height: 1.3;
 }
 #display-root .answer {
   margin-top: 3rem;

--- a/project/web/styles.css
+++ b/project/web/styles.css
@@ -98,10 +98,11 @@ select {
   max-width: 60vw;
   padding: 2.5rem 3rem;
   border-radius: 1.5rem;
-  background: rgba(0, 0, 0, 0.6);
   font-size: 3rem;
   font-weight: 600;
   line-height: 1.3;
+  position: fixed;
+  justify-self: center;
 }
 #display-root .answer {
   margin-top: 3rem;


### PR DESCRIPTION
## Summary
- reuse the duel layout to show the winner banner when a result is declared so the clocks and item remain visible
- add a standby state that renders the standby sentence in the duel view, freezes the clock, and disables the operator “Next Item” control
- style the new status banner and standby message blocks on the display screen

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cc676c8d7c832095c315502ade67de