### PR TITLE
Center duel ready intro

### DIFF
--- a/project/web/display.js
+++ b/project/web/display.js
@@ -32,7 +32,16 @@ function render() {
     const left = state.players.find(p=>p.id===state.leftPlayerId)?.name || 'Left';
     const right = state.players.find(p=>p.id===state.rightPlayerId)?.name || 'Right';
     const cat = manifest.categories.find(c=>c.id===state.current.categoryId)?.name || '';
-    root.innerHTML = `<h2>${cat}</h2><div class="ready"><span>${left}</span> vs <span>${right}</span></div>`;
+    root.innerHTML = `
+      <div class="duel-ready">
+        <div class="duel-category">${cat}</div>
+        <div class="duel-vs">
+          <span class="player-name">${left}</span>
+          <span class="vs-text">vs</span>
+          <span class="player-name">${right}</span>
+        </div>
+      </div>
+    `;
   } else if (scene === 'duel_live' || scene === 'pause' || scene === 'result') {
     renderDuelScene(scene);
   }

--- a/project/web/styles.css
+++ b/project/web/styles.css
@@ -108,9 +108,37 @@ select {
   margin-top: 3rem;
   font-size: 2.8rem;
 }
-.ready span {
-  font-size: 2rem;
-  margin: 0 1rem;
+.duel-ready {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.5rem;
+  text-align: center;
+}
+.duel-category {
+  font-size: clamp(2.5rem, 5vw, 4rem);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+.duel-vs {
+  display: flex;
+  align-items: center;
+  gap: clamp(1.5rem, 4vw, 3rem);
+  font-size: clamp(3rem, 6vw, 5rem);
+  font-weight: 700;
+  letter-spacing: 0.05em;
+}
+.duel-vs .player-name {
+  font-size: 1em;
+}
+.duel-vs .vs-text {
+  font-size: 0.8em;
+  text-transform: uppercase;
+  opacity: 0.8;
 }
 .modal {
   background: #222;


### PR DESCRIPTION
## Summary
- update the duel-ready screen markup to use dedicated elements for the category and player matchup text
- style the duel-ready layout so it is centered on screen and scales to a larger size for easier readability

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cc716ff1888320a40d979878c865c1