### PR TITLE
Add operator-controlled victory screen trigger

### DIFF
--- a/project/web/app.js
+++ b/project/web/app.js
@@ -37,6 +37,7 @@ export function migrateState(s) {
     });
   }
   if (s.winnerId === undefined) s.winnerId = null;
+  if (s.victory === undefined) s.victory = null;
   return s;
 }
 
@@ -60,6 +61,7 @@ export function freshState() {
     penaltyUntil: null,
     correctUntil: null,
     winnerId: null,
+    victory: null,
   };
 }
 
@@ -76,6 +78,9 @@ export function loadState() {
 
 export function saveState(state, options = {}) {
   const { broadcast = true } = options;
+  if (state.scene !== 'victory') {
+    state.victory = null;
+  }
   state.lastSavedAt = Date.now();
   localStorage.setItem(LS_STATE, JSON.stringify(state));
   if (broadcast) channel.postMessage(state);

--- a/project/web/operator.html
+++ b/project/web/operator.html
@@ -41,6 +41,7 @@
     <div class="controls">
       <button id="show-players-screen">Show Players Screen</button>
       <button id="show-random-player">Show Random Player</button>
+      <button id="show-victory" disabled>Show Victory Screen</button>
     </div>
   </section>
 

--- a/project/web/styles.css
+++ b/project/web/styles.css
@@ -198,6 +198,112 @@ select {
   font-weight: normal;
 }
 
+.victory-screen {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  pointer-events: none;
+  opacity: 0;
+  transform: scale(1.02);
+  transition: opacity 300ms ease, transform 600ms cubic-bezier(0.16, 1, 0.3, 1);
+  z-index: 50;
+}
+
+.victory-screen.is-visible {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.victory-backdrop {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    135deg,
+    var(--victory-color-light, #ffffff),
+    var(--victory-color, #f5f5f5),
+    var(--victory-color-dark, #bbbbbb)
+  );
+  filter: saturate(1.2);
+}
+
+.victory-content {
+  position: relative;
+  z-index: 2;
+  padding: clamp(2.5rem, 5vw, 5.5rem) clamp(3rem, 7vw, 6.5rem);
+  border-radius: 2.75rem;
+  text-align: center;
+  color: var(--victory-text-color, #111);
+  background: rgba(255, 255, 255, 0.2);
+  backdrop-filter: blur(18px) saturate(120%);
+  box-shadow: 0 2.5rem 5rem rgba(0, 0, 0, 0.3);
+}
+
+.victory-heading {
+  font-size: clamp(1.5rem, 3.2vw, 2.5rem);
+  font-weight: 700;
+  letter-spacing: 0.4em;
+  text-transform: uppercase;
+  opacity: 0.85;
+}
+
+.victory-name {
+  font-size: clamp(3.5rem, 12vw, 8rem);
+  font-weight: 900;
+  margin-top: clamp(0.75rem, 2vw, 1.5rem);
+  line-height: 0.95;
+  text-shadow: 0 1.25rem 3rem rgba(0, 0, 0, 0.25);
+}
+
+.victory-subtitle {
+  margin-top: clamp(1.25rem, 3vw, 2.5rem);
+  font-size: clamp(1.5rem, 4vw, 3rem);
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.victory-detail {
+  margin-top: clamp(0.75rem, 2vw, 1.5rem);
+  font-size: clamp(1.1rem, 2.5vw, 1.85rem);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.9;
+}
+
+.confetti-container {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  pointer-events: none;
+  z-index: 1;
+}
+
+.confetti-piece {
+  position: absolute;
+  top: -15vh;
+  border-radius: 0.35rem;
+  animation-name: confetti-fall;
+  animation-timing-function: linear;
+  animation-iteration-count: infinite;
+}
+
+@keyframes confetti-fall {
+  0% {
+    transform: translate3d(0, -120vh, 0) rotate(var(--confetti-start, 0deg));
+    opacity: 0;
+  }
+  10% {
+    opacity: 1;
+  }
+  100% {
+    transform: translate3d(var(--confetti-end, 0), 120vh, 0) rotate(var(--confetti-rotation, 360deg));
+    opacity: 0;
+  }
+}
+
 
 .random-player-screen {
   position: fixed;


### PR DESCRIPTION
## Summary
- add an operator victory button that enables when a single player controls the grid and displays their name before triggering the celebration
- persist the selected champion in state and only show the celebration scene on the display when the operator activates it
- retain the full-screen victory presentation with confetti, gradient backdrop, and typography for the winning player

## Testing
- not run (web UI changes only)

------
https://chatgpt.com/codex/tasks/task_e_68d0065f34a88320bf4f248709f1ac90